### PR TITLE
New error function to optionally show link to GitHub

### DIFF
--- a/src/seut_errors.py
+++ b/src/seut_errors.py
@@ -98,7 +98,7 @@ def isCollectionExcluded(collectionName, allCurrentViewLayerCollections):
                     else:
                         return False
 
-def showErrorNew(self, context, err_type: str, err_message: str, show_link = True):
+def showErrorNew(self, context, err_type: str, err_message: str, show_link=True):
     def draw(self, context):
         # self.layout.label(text=self.p_text)
         # self.layout.label()

--- a/src/seut_errors.py
+++ b/src/seut_errors.py
@@ -15,27 +15,22 @@ def errorExportGeneral(self, context):
 
     # If file is still startup file (hasn't been saved yet), it's not possible to derive a path from it.
     if not bpy.data.is_saved:
-        self.report({'ERROR'}, "SEUT: BLEND file must be saved before export. (008)")
-        print("SEUT Error: BLEND file must be saved before export. (008)")
+        showErrorNew(self, context=context, err_type='ERROR', err_message="SEUT Error: BLEND file must be saved before export. (008)")
         return {'CANCELLED'}
 
     if os.path.exists(exportPath) == False:
-        self.report({'ERROR'}, "SEUT: Export path '%s' doesn't exist. (003)" % (exportPath))
-        print("SEUT Error: Export path '" + exportPath + "' doesn't exist. (003)")
+        showErrorNew(self, context=context, err_type='ERROR', err_message="SEUT: Export path '%s' doesn't exist. (003)" % exportPath)
         return {'CANCELLED'}
     elif scene.seut.export_exportPath == "":
-        self.report({'ERROR'}, "SEUT: No export folder defined. (003)")
-        print("SEUT Error: No export folder defined. (003)")
+        showErrorNew(self, context=context, err_type='ERROR', err_message="SEUT Error: No export folder defined. (003)")
         return {'CANCELLED'}
 
     if scene.seut.export_exportPath.find("Models\\") == -1:
-        self.report({'ERROR'}, "SEUT: Export path '%s' does not contain 'Models\\'. Cannot be transformed into relative path. (014)" % (exportPath))
-        print("SEUT Error: Export path '" + exportPath + "' does not contain 'Models\\'. Cannot be transformed into relative path. (014)")
+        showErrorNew(self, context=context, err_type='ERROR', err_message="SEUT: Export path '%s' does not contain 'Models\\'. Cannot be transformed into relative path. (014)" % exportPath)
         return {'CANCELLED'}
 
     if scene.seut.subtypeId == "":
-        self.report({'ERROR'}, "SEUT: No SubtypeId set. (004)")
-        print("SEUT Error: No SubtypeId set. (004)")
+        showErrorNew(self, context=context, err_type='ERROR', err_message="SEUT: No SubtypeId set. (004)")
         return {'CANCELLED'}
 
     return {'CONTINUE'}
@@ -50,28 +45,25 @@ def errorCollection(self, scene, collection, partial):
             print("SEUT Warning: Collection not found. Action not possible.")
             return {'FINISHED'}
         else:
-            self.report({'ERROR'}, "SEUT: Collection not found. Action not possible. (002)")
-            print("SEUT Error: Collection not found. Action not possible. (002)")
+            showErrorNew(self, context=context, err_type='ERROR', err_message="SEUT: Collection not found. Action not possible. (002)")
             return {'CANCELLED'}
             
     isExcluded = isCollectionExcluded(collection.name, allCurrentViewLayerCollections)
 
     if isExcluded or isExcluded is None:
         if partial:
-            print("SEUT Warning: Collection '" + collection.name + "' excluded from view layer or cannot be found. Action not possible.")
+            print("SEUT Warning: Collection '%s' excluded from view layer or cannot be found. Action not possible." % collection.name)
             return {'FINISHED'}
         else:
-            self.report({'ERROR'}, "SEUT: Collection '%s' excluded from view layer or cannot be found. Action not possible. (019)" % (collection.name))
-            print("SEUT Error: Collection '" + collection.name + "' excluded from view layer or cannot be found. Action not possible. (019)")
+            showErrorNew(self, context=context, err_type='ERROR', err_message="SEUT: Collection '%s' excluded from view layer or cannot be found. Action not possible. (019)" % collection.name)
             return {'CANCELLED'}
 
     if len(collection.objects) == 0:
         if partial:
-            print("SEUT Warning: Collection '" + collection.name + "' is empty. Action not possible.")
+            print("SEUT Warning: Collection '%s' is empty. Action not possible." % collection.name)
             return {'FINISHED'}
         else:
-            self.report({'ERROR'}, "SEUT: Collection '%s' is empty. Action not possible. (005)" % (collection.name))
-            print("SEUT Error: Collection '" + collection.name + "' is empty. Action not possible. (005)")
+            showErrorNew(self, context=context, err_type='ERROR', err_message="SEUT: Collection '%s' is empty. Action not possible. (005)" % collection.name)
             return {'CANCELLED'}
     
     return {'CONTINUE'}
@@ -80,14 +72,12 @@ def errorToolPath(self, toolPath, toolName, toolFileName):
     """Checks if external tool is correctly linked"""
 
     if toolPath == "" or toolPath == "." or os.path.exists(toolPath) is False:
-        self.report({'ERROR'}, "SEUT: Path to %s '%s' not valid. (012)" % (toolName, toolPath))
-        print("SEUT Error: Path to " + toolName + " '" + toolPath + "' not valid. (012)")
+        showErrorNew(self, context=context, err_type='ERROR', err_message="SEUT: Path to %s '%s' not valid. (012)" % (toolName, toolPath))
         return {'CANCELLED'}
 
     fileName = os.path.basename(toolPath)
     if toolFileName != fileName:
-        self.report({'ERROR'}, "SEUT: Path to %s not valid - wrong target file: Expected '%s' but is set to '%s'. (013)" % (toolName, toolFileName, fileName))
-        print("SEUT Error: Path to " + toolName + " not valid - wrong target file: Expected '" + toolFileName + "' but is set to '" + fileName + "'. (013)")
+        showErrorNew(self, context=context, err_type='ERROR', err_message="SEUT: Path to %s not valid - wrong target file: Expected '%s' but is set to '%s'. (013)" % (toolName, toolFileName, fileName))
         return {'CANCELLED'}
     
     return {'CONTINUE'}
@@ -107,7 +97,18 @@ def isCollectionExcluded(collectionName, allCurrentViewLayerCollections):
                         return True
                     else:
                         return False
-                        
+
+def showErrorNew(self, context, err_type: str, err_message: str, show_link = True):
+    def draw(self, context):
+        # self.layout.label(text=self.p_text)
+        # self.layout.label()
+        self.layout.label()
+        self.layout.label( )
+        self.layout.operator('wm.get_update', icon='IMPORT', text='Open GitHub page')
+
+    self.report({err_type}, err_message)
+    print(err_message)
+    if show_link: bpy.context.window_manager.popup_menu(draw, title=err_message, icon='NONE')
 
 def draw_error(self, context):
     wm = context.window_manager


### PR DESCRIPTION
Created new error function `showErrorNew` which takes 3 arguments in order to change the error type, the message itself and the toggle for the secondary messagebox for the link operator.

This way the error message string only needs to be hard coded once.

When triggered, it will look like this:
![Screenshot_20200910_200139](https://user-images.githubusercontent.com/36563538/92778092-24265e80-f3a1-11ea-9b44-06da534453e8.png)
