### PR TITLE
Add per-object convex radius for Havok collision ex…

### DIFF
--- a/space-engineers-utilities/export/seut_custom_fbx_exporter.py
+++ b/space-engineers-utilities/export/seut_custom_fbx_exporter.py
@@ -170,6 +170,8 @@ def fbx_data_object_elements(root, ob_obj, scene_data):
         _fbx.elem_props_template_set(tmpl, props, "p_double", b"restitution", rbo.restitution)
         _fbx.elem_props_template_set(tmpl, props, "p_string", b"hkTypeShape", "hkShape")
         _fbx.elem_props_template_set(tmpl, props, "p_string", b"shapeType", shapeType)
+        if rbo.use_margin:
+            _fbx.elem_props_template_set(tmpl, props, "p_double", b"extraRadius", rbo.collision_margin)
 
     # ------------------------ CUSTOM PART ENDS HERE ------------------------ #
 


### PR DESCRIPTION
Add option to specify per-object convex radius for Havok collisions. Value set to "Margin" property under Rigid Body > Collisions > Sensitivity