### PR TITLE
Adding a warning regarding compatibility of SEUT and Blender versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ A Blender 3.0+ addon to streamline working on assets for Space Engineers.
 
 ## Installation
 Please follow the [installation guide](https://semref.atlassian.net/wiki/spaces/tutorials/pages/131411/SEUT+Installation+Guide).
+> [!WARNING]
+> As of Blender 4.0, when using SEUT release 1.1.0, exporting causes errors. You may want to stick to Blender 3 if you want to use a stable SEUT release. This issue is fixed in release 1.2.0-beta.2, but considering it is a developpement release, it might not be suitable for first time user.
 
 ## Credits	
 * **Stollie** - So much general help but also writing everything character, export and MWM-related, which I wouldn't have been able to do at all.	


### PR DESCRIPTION
Hi

This pull requests adds a warning in the [Installation](https://github.com/enenra/space-engineers-utilities?tab=readme-ov-file#installation) sections of the repository's Readme. This addition warns users of the compatibility issues between [SEUT 1.1.0](https://github.com/enenra/space-engineers-utilities/releases/tag/v1.1.0)<= and Blender 4.0>=. 

This warning recommends first time users to stick to Blender 3, but reminds that release [1.2.0-beta.2](https://github.com/enenra/space-engineers-utilities/releases/tag/v1.2.0-beta.2) fixes the compatibility issues if people whish to use a development release.

This pull request has been made following the issue #396. This was just drafted quickly to save you some time and work if you want to have something written but don't want to bother touching the readme ^^
